### PR TITLE
Replace package file path contraction from package.Id and package.Versio...

### DIFF
--- a/src/Server/Infrastructure/Lucene/LucenePackageRepository.cs
+++ b/src/Server/Infrastructure/Lucene/LucenePackageRepository.cs
@@ -165,7 +165,7 @@ namespace NuGet.Server.Infrastructure.Lucene
 
         public LucenePackage LoadFromFileSystem(string path)
         {
-            return Convert(OpenPackage(path), new LucenePackage(FileSystem, _ => FileSystem.OpenFile(path)));
+            return Convert(path, OpenPackage(path), new LucenePackage(FileSystem, _ => FileSystem.OpenFile(path)));
         }
 
         public LucenePackage Convert(IPackage package)
@@ -177,14 +177,17 @@ namespace NuGet.Server.Infrastructure.Lucene
             return Convert(package, lucenePackage);
         }
 
-        private LucenePackage Convert(IPackage package, LucenePackage lucenePackage)
+        private LucenePackage Convert(IPackage package, LucenePackage lucenePackage) {
+            return Convert(GetPackageFilePath(lucenePackage), package, lucenePackage);
+        }
+
+        private LucenePackage Convert(string packageFilePath, IPackage package, LucenePackage lucenePackage)
         {
             Mapper.Map(package, lucenePackage);
 
-            var path = GetPackageFilePath(lucenePackage);
-            lucenePackage.Path = path;
+            lucenePackage.Path = packageFilePath;
 
-            var derivedData = CalculateDerivedData(lucenePackage, path, lucenePackage.GetStream());
+            var derivedData = CalculateDerivedData(lucenePackage, packageFilePath, lucenePackage.GetStream());
 
             Mapper.Map(derivedData, lucenePackage);
 


### PR DESCRIPTION
...n with usage actual package file location path.

It looks logical to store original package file location path to lucene index path fields. In this case packages could be indexed and fetched regardless of actual file locations in ~/Packages directory.
